### PR TITLE
Replace Deprecated ChatMessage class with New Classes from Azure.AI.OpenAI 1.0.0-beta.11

### DIFF
--- a/SharedLib/Services/OpenAiService.cs
+++ b/SharedLib/Services/OpenAiService.cs
@@ -168,8 +168,8 @@ public class OpenAiService
         try
         {
         
-            ChatMessage systemMessage = new ChatMessage(ChatRole.System, _systemPromptRetailAssistant + documents);
-            ChatMessage userMessage = new ChatMessage(ChatRole.User, userPrompt);
+            ChatRequestSystemMessage systemMessage = new ChatRequestSystemMessage(_systemPromptRetailAssistant + documents);
+            ChatRequestUserMessage userMessage = new ChatRequestUserMessage(userPrompt);
 
 
             ChatCompletionsOptions options = new()
@@ -219,8 +219,8 @@ public class OpenAiService
     public async Task<string> SummarizeAsync(string sessionId, string userPrompt)
     {
 
-        ChatMessage systemMessage = new ChatMessage(ChatRole.System, _summarizePrompt);
-        ChatMessage userMessage = new ChatMessage(ChatRole.User, userPrompt);
+        ChatRequestSystemMessage systemMessage = new ChatRequestSystemMessage(_summarizePrompt);
+        ChatRequestUserMessage userMessage = new ChatRequestUserMessage(userPrompt);
 
         ChatCompletionsOptions options = new()
         {


### PR DESCRIPTION
As of version 1.0.0-beta.11 of Azure.AI.OpenAI, the ChatMessage class has been deprecated. It has been replaced with two distinct classes: ChatRequestSystemMessage and ChatRequestUserMessage.

Changes:

Replaced all instances of ChatMessage with ChatRequestSystemMessage or ChatRequestUserMessage, as appropriate.
References:

https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/README.md